### PR TITLE
Fixed version link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Manage Windows Apps (.intunewin) with Intune
 
-[Version 1.8.3](https://github.com/Microsoft/Microsoft-Win32-Content-Prep-Tool/releases/tag/v1.8.3)
+[Version 1.8.3](https://github.com/Microsoft/Microsoft-Win32-Content-Prep-Tool/releases/tag/1.8.3)
 
 [See release notes for more information.](https://github.com/Microsoft/Microsoft-Win32-Content-Prep-Tool/releases)
 


### PR DESCRIPTION
Resolves #59

In the latest version (`1.8.3`), the release tag was changed from `v(version)` to just `(version)`. The [README.md](https://github.com/microsoft/Microsoft-Win32-Content-Prep-Tool/blob/master/README.md) link to this release is currently incorrect and showing a 404 page.